### PR TITLE
Fix interaction with metaclass type annotations and `type` not generating `__annotations__` if no annotations are present.

### DIFF
--- a/interface_meta/interface.py
+++ b/interface_meta/interface.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from collections.abc import Callable
-from typing import Any, ClassVar, TypeVar, overload
+from typing import Any, TypeVar, overload
 
 from .utils.conformance import verify_conformance, verify_not_overridden
 from .utils.docs import update_docs
@@ -26,9 +26,13 @@ class InterfaceMeta(ABCMeta):
     subclass operations.
     """
 
-    INTERFACE_EXPLICIT_OVERRIDES: ClassVar[bool] = True
-    INTERFACE_RAISE_ON_VIOLATION: ClassVar[bool] = False
-    INTERFACE_SKIPPED_NAMES: ClassVar[set[str]] = set()
+    # DO NOT ADD TYPES TO THESE CLASS VARS!
+    # This causes derived classes to not have "__annotations__" set to the
+    # empty dictionary when they do not explicitly define any annotations, which
+    # breaks the standard Python convention. This is an interaction with `type`.
+    INTERFACE_EXPLICIT_OVERRIDES = True
+    INTERFACE_RAISE_ON_VIOLATION = False
+    INTERFACE_SKIPPED_NAMES = set()  # type: ignore  # noqa: RUF012
 
     def __init__(
         cls,

--- a/interface_meta/interface.py
+++ b/interface_meta/interface.py
@@ -39,8 +39,10 @@ class InterfaceMeta(ABCMeta):
         name: str,
         bases: tuple[type, ...],
         dct: dict[str, Any],
+        /,
+        **kwargs: Any,
     ) -> None:
-        ABCMeta.__init__(cls, name, bases, dct)
+        ABCMeta.__init__(cls, name, bases, dct, **kwargs)
 
         # Register interface class for subclasses
         if not hasattr(cls, "__interface__"):
@@ -53,7 +55,6 @@ class InterfaceMeta(ABCMeta):
 
         # Iterate over names in `dct` and check for conformance to interface
         for key, value in dct.items():
-
             # Skip any key corresponding to Python magic methods
             if key.startswith("__") and key.endswith("__"):
                 continue
@@ -79,9 +80,7 @@ class InterfaceMeta(ABCMeta):
                         raise_on_violation=raise_on_violation,
                     )
                     break
-                if key in getattr(
-                    base, "__annotations__", {}
-                ):  # Declared but as yet unspecified attributes
+                if key in getattr(base, "__annotations__", {}):  # Declared but as yet unspecified attributes
                     is_override = True
                     cls.__verify_conformance(
                         key,
@@ -95,9 +94,7 @@ class InterfaceMeta(ABCMeta):
                     break
 
             if not is_override:
-                verify_not_overridden(
-                    key, name, value, raise_on_violation=raise_on_violation
-                )
+                verify_not_overridden(key, name, value, raise_on_violation=raise_on_violation)
 
         # Update documentation
         cls.__update_docs(cls, name, bases, dct)

--- a/interface_meta/utils/conformance.py
+++ b/interface_meta/utils/conformance.py
@@ -35,9 +35,7 @@ def verify_conformance(
         raise_on_violation: Whether any non-conformance should cause an
             exception to be raised. (default: False)
     """
-    if hasattr(
-        ref_member, "__objclass__"
-    ):  # pragma: no cover; Method is attached to metaclass, so should not be checked.
+    if hasattr(ref_member, "__objclass__"):  # pragma: no cover; Method is attached to metaclass, so should not be checked.
         return
 
     if ref_member is None or has_forced_override(member) or should_skip(ref_member):
@@ -59,11 +57,7 @@ def verify_conformance(
             pass
 
     # Check that overrides are present
-    if (
-        is_functional_member(member)
-        or inspect.isdatadescriptor(member)
-        or inspect.ismethoddescriptor(member)
-    ):
+    if is_functional_member(member) or inspect.isdatadescriptor(member) or inspect.ismethoddescriptor(member):
         if explicit_overrides and not has_explicit_override(member):
             report_violation(
                 f"`{clsname}.{name}` overrides interface `{ref_clsname}.{name}` without using the `@override` decorator.",
@@ -130,34 +124,20 @@ def check_signatures_compatible(sig: Signature, ref_sig: Signature) -> bool:
         for bp in base_params:
             cp = next(params)
 
-            while (
-                bp.kind is Parameter.VAR_POSITIONAL
-                and cp.kind is Parameter.POSITIONAL_OR_KEYWORD
-            ):
+            while bp.kind is Parameter.VAR_POSITIONAL and cp.kind is Parameter.POSITIONAL_OR_KEYWORD:
                 cp = next(params)
 
-            while (
-                bp.kind is Parameter.VAR_KEYWORD
-                and cp.kind is not Parameter.VAR_KEYWORD
-            ):
+            while bp.kind is Parameter.VAR_KEYWORD and cp.kind is not Parameter.VAR_KEYWORD:
                 cp = next(params)
 
-            if not (
-                cp.name == bp.name and bp.kind == cp.kind and bp.default == cp.default
-            ):
+            if not (cp.name == bp.name and bp.kind == cp.kind and bp.default == cp.default):
                 raise ValueError(bp, cp)
 
     except (StopIteration, ValueError):
         return False
 
     for param in params:
-        if (
-            param.kind is Parameter.POSITIONAL_ONLY
-            or (
-                param.kind is Parameter.POSITIONAL_OR_KEYWORD
-                and param.default is Parameter.empty
-            )
-        ):
+        if param.kind is Parameter.POSITIONAL_ONLY or (param.kind is Parameter.POSITIONAL_OR_KEYWORD and param.default is Parameter.empty):
             return False
 
     return True

--- a/interface_meta/utils/docs.py
+++ b/interface_meta/utils/docs.py
@@ -48,9 +48,7 @@ def update_docs(
         if has_class_attr_docs(klass):
             module_docs.append(
                 [
-                    "Attributes:"
-                    if klass is cls
-                    else f"Attributes inherited from {klass.__name__}:",
+                    "Attributes:" if klass is cls else f"Attributes inherited from {klass.__name__}:",
                     inspect.cleandoc(get_class_attr_docs(klass) or ""),
                 ]
             )
@@ -60,17 +58,10 @@ def update_docs(
     # Assemble class attribute names avoiding dunder methods
     members: dict[str, Any] = {}
     for klass in reversed(cls.mro()):
-        members.update(
-            {
-                name: member
-                for name, member in klass.__dict__.items()
-                if not name.startswith("__") and not name.endswith("__")
-            }
-        )
+        members.update({name: member for name, member in klass.__dict__.items() if not name.startswith("__") and not name.endswith("__")})
 
     # Handle function/method-level documentation
     for name, member in members.items():
-
         # Check if there is anything to do
         if not has_updatable_docs(member):
             continue
@@ -104,16 +95,11 @@ def update_docs(
             quirk_member_docs = get_functional_docs(quirk_member)
             if quirk_member_docs:
                 if cls.__name__ in method_docs:
-                    method_docs[cls.__name__] = (
-                        inspect.cleandoc(method_docs[cls.__name__] or "")
-                        + "\n\n"
-                        + inspect.cleandoc(quirk_member_docs)
-                    )
+                    method_docs[cls.__name__] = inspect.cleandoc(method_docs[cls.__name__] or "") + "\n\n" + inspect.cleandoc(quirk_member_docs)
                 else:
                     method_docs[cls.__name__] = quirk_member_docs
 
         if method_docs:
-
             if name not in cls.__dict__:
                 # Override method object with new object so we don't modify
                 # underlying method that may be shared by multiple classes.
@@ -121,12 +107,7 @@ def update_docs(
 
             set_functional_docs(
                 member,
-                doc_join(
-                    *[
-                        docs if i == 0 else [source + " Quirks:", docs]
-                        for i, (source, docs) in enumerate(method_docs.items())
-                    ]
-                ),
+                doc_join(*[docs if i == 0 else [source + " Quirks:", docs] for i, (source, docs) in enumerate(method_docs.items())]),
             )
 
             if name not in cls.__dict__:

--- a/interface_meta/utils/inspection.py
+++ b/interface_meta/utils/inspection.py
@@ -41,10 +41,7 @@ def is_functional_member(member: object) -> bool:
     Returns:
         `True` if the member is a function (or acts like one).
     """
-    return inspect.isfunction(member) or (
-        inspect.ismethoddescriptor(member)
-        and isinstance(member, (classmethod, staticmethod))
-    )
+    return inspect.isfunction(member) or (inspect.ismethoddescriptor(member) and isinstance(member, (classmethod, staticmethod)))
 
 
 def get_functional_signature(member: object) -> inspect.Signature:
@@ -149,9 +146,7 @@ def set_skip(member: object, skip: bool = True) -> None:
 
 
 def has_updatable_docs(member: object) -> bool:
-    return is_functional_member(member) or (
-        inspect.isdatadescriptor(member) and isinstance(member, property)
-    )
+    return is_functional_member(member) or (inspect.isdatadescriptor(member) and isinstance(member, property))
 
 
 def get_functional_docs(member: object, orig: bool = True) -> str | None:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -113,23 +113,11 @@ def test_raise_on_violation():
 
 
 def test_docstrings():
-    assert (
-        SubBase.__doc__
-        == "SubBase class\n\nAttributes inherited from Base:\n    ATTRIBUTE (str): An attribute."
-    )
+    assert SubBase.__doc__ == "SubBase class\n\nAttributes inherited from Base:\n    ATTRIBUTE (str): An attribute."
     assert SubBase.__init__.__doc__ == "Subclass Constructor"
     assert SubBase.property_method.__doc__ == "Property Method"
-    assert (
-        SubBase.regular_method.__doc__
-        == "Regular Method\n\nSubBase Quirks:\n    Subclass Regular Method"
-    )
-    assert (
-        SubBase.static_method.__doc__
-        == "Static Method\n\nSubBase Quirks:\n    Subclass Static Method"
-    )
+    assert SubBase.regular_method.__doc__ == "Regular Method\n\nSubBase Quirks:\n    Subclass Regular Method"
+    assert SubBase.static_method.__doc__ == "Static Method\n\nSubBase Quirks:\n    Subclass Static Method"
     assert SubBase.class_method.__doc__ == "Subclass Class Method"
-    assert (
-        SubBase.split_method.__doc__
-        == "Split Method\n\nSubBase Quirks:\n    Subclass split_method quirks"
-    )
+    assert SubBase.split_method.__doc__ == "Split Method\n\nSubBase Quirks:\n    Subclass split_method quirks"
     assert SubBase.mro_documented.__doc__ == "Documentation in SubBase"

--- a/tests/utils/test_inspection.py
+++ b/tests/utils/test_inspection.py
@@ -29,7 +29,6 @@ from interface_meta.utils.inspection import (
 
 
 class Test:
-
     __doc_attrs = "Documented attributes"
 
     attribute = False
@@ -110,9 +109,7 @@ def test_get_functional_wrapper():
             "__override_force__",
         ]:
             if functional_hasattr(functional, attr):
-                assert functional_getattr(wrapped, attr) == functional_getattr(
-                    functional, attr
-                )
+                assert functional_getattr(wrapped, attr) == functional_getattr(functional, attr)
 
         if functional is PROPERTY:
             assert wrapped.fset is PROPERTY.fset
@@ -121,12 +118,8 @@ def test_get_functional_wrapper():
 
 def test_get_functional_signature():
     assert get_functional_signature(METHOD) == signature(METHOD)
-    assert get_functional_signature(CLASS_METHOD) == signature(
-        CLASS_METHOD.__get__(object, object).__func__
-    )
-    assert get_functional_signature(STATIC_METHOD) == signature(
-        STATIC_METHOD.__get__(object, object)
-    )
+    assert get_functional_signature(CLASS_METHOD) == signature(CLASS_METHOD.__get__(object, object).__func__)
+    assert get_functional_signature(STATIC_METHOD) == signature(STATIC_METHOD.__get__(object, object))
 
 
 def test_functional_attrs():


### PR DESCRIPTION
This causes some downstream runtime type-checkers to fail. This is likely a bug in `type`.